### PR TITLE
Create Dockerfile / 新建 Dockerfile 文件

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN pip install python-telegram-bot[socks]
 
 FROM python:3.9-alpine
 
-WORKDIR /app
-
 COPY --from=build /app /app
 COPY --from=build /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
+
+WORKDIR /app
 
 CMD python src/__main__.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.9 as build
+
+COPY . /app
+
+WORKDIR /app
+
+RUN pip install -e .
+RUN pip install python-telegram-bot[socks]
+
+FROM python:3.9-alpine
+
+WORKDIR /app
+
+COPY --from=build /app /app
+COPY --from=build /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
+
+CMD python src/__main__.py


### PR DESCRIPTION
我写了一个 Dockerfile，成功生成了 90M 大小的 Docker 镜像并通过测试。
该镜像运行参数如下：

```
docker run -d --name qzone2tg \
-v $HOME/qzone2tg-data/config:/app/config \
-v $HOME/qzone2tg-data/data:/app/data \
jamzumsum/qzone2tg:latest
```

1. 如使用 webhook 模式，还需设置 -p 端口映射。
2. 证书和私钥可放在 config 文件夹里。

需要注意的是，若要从此 Dockerfile 构建此镜像，还需对本项目根目录下的 `src/__main__.py` 文件做一点点改动：

将第 33 行的 `pwd: str = getpass('Password (press Enter to skip):')` 注释掉
并在下面新增一行： `pwd = ""`

原因：当 Docker 容器以后台 (-d) 模式运行时，应用无法从控制台接收到用户的输入，这么做相当于按回车直接跳过。如需使用密码登录可直接修改配置文件。

当然我相信开发者有更好的解决方案，当前方案可作为临时使用。
